### PR TITLE
Fix missing `.into()` when parsing targets

### DIFF
--- a/lib/turf_internals/src/settings.rs
+++ b/lib/turf_internals/src/settings.rs
@@ -25,7 +25,7 @@ impl<'a> From<Settings> for lightningcss::printer::PrinterOptions<'a> {
         lightningcss::printer::PrinterOptions {
             minify: val.minify.unwrap_or(true),
             project_root: None,
-            targets: val.browser_targets.map(From::<BrowserVersions>::from),
+            targets: val.browser_targets.map(From::<BrowserVersions>::from).into(),
             analyze_dependencies: None,
             pseudo_classes: None,
         }


### PR DESCRIPTION
This is an attempt to solve this issue. I hope this is the right way.

Credits goes to the team leader at my company - Vincent for quickly solving it.
