### PR TITLE
Set `ClassName` to pub

### DIFF
--- a/lib/turf_macros/src/lib.rs
+++ b/lib/turf_macros/src/lib.rs
@@ -54,7 +54,7 @@ fn create_classes_structure(classes: HashMap<String, String>) -> proc_macro2::To
 
     quote::quote! {
         #[doc=#doc]
-        struct ClassName;
+        pub struct ClassName;
         impl ClassName {
             #(pub const #original_class_names: &'static str = #randomized_class_names;)*
         }
@@ -78,7 +78,7 @@ mod tests {
             out.to_string(),
             quote::quote! {
                 #[doc="TEST_CLASS = \"abc-123\"\n"]
-                struct ClassName;
+                pub struct ClassName;
                 impl ClassName {
                     pub const TEST_CLASS: &'static str = "abc-123";
                 }


### PR DESCRIPTION
## What?

Allow reusability of the same CSS _(hashed)_ across multiple UI components files.

## How?

Add `pub` modifier to the struct [`ClassName`](https://github.com/myFavShrimp/turf/blob/360074a9f894b30124ada126f08224462a8c0ffe/lib/turf_macros/src/lib.rs#L57C10-L57C10)

## Why?

Example from my recent case:

I have the components:

- `<Button />`
- `<ButtonIcon />`

Both of them share the same CSS. Instead of creating and duplicating the same CSS files for each of them, I can create just one, in a separate mod file, then "re-export" it, so both of those components _(in separated files)_ can **reuse** the same CSS.

### Example

```rs
// button/styles.rs
style_sheet!("/button/styles.scss");

pub static BUTTON_STYLE_SHEET: &str = STYLE_SHEET;
pub type ButtonClassName = ClassName;
```

```rs
// button/default.rs

use super::super::utils::{ButtonClassName, BUTTON_STYLE_SHEET};

pub static STYLE_SHEET: &str = BUTTON_STYLE_SHEET;

impl yew::Component for Button {
  // ...
}
```

```rs
// button/icon.rs

use super::super::utils::{ButtonClassName, BUTTON_STYLE_SHEET};

pub static STYLE_SHEET: &str = BUTTON_STYLE_SHEET;

impl yew::Component for ButtonIcon {
  // ...
}
```

---

This is best I could come up with possible solution to solve this case.
Please let me know what do you think, or if you have a better solution for my case.

Thanks! ❤️
