### PR TITLE
Update lightningcss & implement changes which breaks build

### DIFF
--- a/lib/turf_internals/Cargo.toml
+++ b/lib/turf_internals/Cargo.toml
@@ -18,7 +18,7 @@ version = "1.0"
 features = ["derive"]
 
 [dependencies.lightningcss]
-version = "=1.0.0-alpha.44"
+version = "1.0.0-alpha.47"
 default-features = false
 features = ["grid", "visitor"]
 

--- a/lib/turf_internals/src/transformer.rs
+++ b/lib/turf_internals/src/transformer.rs
@@ -34,7 +34,9 @@ impl TransformationVisitor {
 impl<'i> Visitor<'i> for TransformationVisitor {
     type Error = Infallible;
 
-    const TYPES: VisitTypes = visit_types!(SELECTORS);
+    fn visit_types(&self) -> VisitTypes {
+        visit_types!(SELECTORS)
+    }
 
     fn visit_selector(&mut self, selectors: &mut Selector<'i>) -> Result<(), Self::Error> {
         for selector in selectors.iter_mut_raw_match_order() {


### PR DESCRIPTION
## What was the issue?

In my project after running `cargo update` I noticed one of the dependencies had updates from the `lightningcss`. And build started to break.

After some investigation I noticed the pinned version of `lightningcss`, but it didn't stop from its dependencies from being updated. 😕

So, I've quickly updated the crate and implemented the change which breaks the build.

Annoying, but oh well.. at least I had a time to investigate and fix it quickly. Not sure what else can be done to prevent it from happening again. Any thoughts?
